### PR TITLE
Fixed error Ambiguous use of 'sheet(isPresented:onDismiss:content:)

### DIFF
--- a/Sources/NativePartialSheet/View+sheetView.swift
+++ b/Sources/NativePartialSheet/View+sheetView.swift
@@ -20,7 +20,7 @@ public struct UnwrapView<T, Content: View>: View {
 }
 
 public extension View {
-    func sheet<Content: View>(
+    func nativePartialSheet<Content: View>(
         isPresented: Binding<Bool>,
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder content: @escaping () -> Content
@@ -33,7 +33,7 @@ public extension View {
         return SheetWrapperView(prefs: prefs, content: self)
     }
     
-    func sheet<Content: View>(
+    func nativePartialSheet<Content: View>(
         selectedDetent: Binding<Detent?>,
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder content: @escaping (Detent) -> Content
@@ -61,7 +61,7 @@ public extension View {
         return SheetWrapperView(prefs: prefs, content: self)
     }
     
-    func sheet<Item: Identifiable, Content: View>(
+    func nativePartialSheet<Item: Identifiable, Content: View>(
         item: Binding<Item?>,
         onDismiss: (() -> Void)? = nil,
         @ViewBuilder content: @escaping (Item) -> Content


### PR DESCRIPTION
This case is happen when use defaut sheet in SwiftUI framework with [NativePartialSheet](https://github.com/CoolONEOfficial/NativePartialSheet)

From this issue
https://github.com/CoolONEOfficial/NativePartialSheet/issues/1#issue-1629582765

**This chage main method name that maybe big change.


- Fixed open nested view
- Fixed view dismiss after preseted



https://github.com/CoolONEOfficial/NativePartialSheet/assets/22313319/77f7e1b5-6735-4402-93d2-c8c8f16d1857

